### PR TITLE
Linebreaks and typos

### DIFF
--- a/Terms of Service/WordPress.com/EN-Terms-of-Service.md
+++ b/Terms of Service/WordPress.com/EN-Terms-of-Service.md
@@ -2,34 +2,173 @@
 
 ### The gist:
 
-We (the [folks at Automattic](http://automattic.com/about/)) run a blog and website hosting platform called [WordPress.com](https://wordpress.com) and would **love** for you to use it. WordPress.com's basic service is free, and we offer paid upgrades for advanced features such as domain hosting and extra storage. Our service is designed to give you as much control and ownership over what goes on your website as possible and encourage you to express yourself freely. However, be responsible in what you publish. In particular, make sure that none of the prohibited items (like spam, viruses, or serious threats of violence) appear on your website. If you find a WordPress.com website that you believe violates these Terms of Service, please [visit our dispute resolution & reporting page](http://en.support.wordpress.com/disputes/).
+We (the [folks at Automattic](http://automattic.com/about/))
+run a blog and website hosting platform called [WordPress.com](https://wordpress.com)
+and would **love** for you to use it. 
+WordPress.com's basic service is free, 
+and we offer paid upgrades for advanced features such as domain hosting and extra storage. 
+Our service is designed to 
+give you as much control and ownership over what goes on your website as possible 
+and encourage you to express yourself freely. 
+However, be responsible in what you publish. 
+In particular, make sure that none of the prohibited items 
+(like spam, viruses, or serious threats of violence) 
+appear on your website. 
+If you find a WordPress.com website that you believe violates these Terms of Service, 
+please [visit our dispute resolution & reporting page](http://en.support.wordpress.com/disputes/).
 
-We also have additional services and products designed to make the web a betterchange place like WordPress.com VIP, WooCommerce, Longreads, VaultPress, Akismet, and Jetpack.
+We also have additional services and products designed to make the web a betterchange place
+like WordPress.com VIP, WooCommerce, Longreads, VaultPress, Akismet, and Jetpack.
 
-(We've made the below Terms of Service available under a [Creative Commons Sharealike](http://creativecommons.org/licenses/by-sa/4.0/) license, which means you're more than welcome to repurpose it for your own use. Just make sure to replace references to us with ones to you, and if you don't mind we'd appreciate a link to WordPress.com somewhere on your website. We spent a lot of money and time on the below, and other people shouldn't need to do the same.)
+(We've made the below Terms of Service available under a 
+[Creative Commons Sharealike](http://creativecommons.org/licenses/by-sa/4.0/) license, 
+which means you're more than welcome to repurpose it for your own use. 
+Just make sure to replace references to us with ones to you, 
+and if you don't mind we'd appreciate a link to WordPress.com somewhere on your website. 
+We spent a lot of money and time on the below, and other people shouldn't need to do the same.)
 
 ### Terms of Service:
 
-The following terms and conditions govern all use of the WordPress.com website and all content, services, and products available at or through the website, including, but not limited to, Jetpack ("Jetpack"), VaultPress ("VaultPress"), and WordPress.com VIP ("VIP Service"), (taken together, our Services). Our Services are offered subject to your acceptance without modification of all of the terms and conditions contained herein and all other operating rules, policies (including, without limitation, [Automattic's Privacy Policy](http://automattic.com/privacy/)) and procedures that may be published from time to time by Automattic (collectively, the "Agreement"). You agree that we may automatically upgrade our Services, and these terms will apply to any upgrades. If you reside in the United States, your agreement is with Automattic Inc. (US), and if you reside outside of the United States, your agreement is with Aut O'Mattic Ltd. (Ireland) (each, "Automattic" or "we"). Please read this Agreement carefully before accessing or using our Services. By accessing or using any part of our services, you agree to become bound by the terms and conditions of this agreement. If you do not agree to all the terms and conditions of this agreement, then you may not access or use any of our services. If these terms and conditions are considered an offer by Automattic, acceptance is expressly limited to these terms. Our Services are not directed to children younger than 13, and access and use of our Services is only offered to users 13 years of age or older. If you are under 13 years old, please do not register to use our Services. Any person who registers as a user or provides their personal information to our Services represents that they are 13 years of age or older. Use of our Services requires a WordPress.com account. You agree to provide us with complete and accurate information when you register for an account. You will be solely responsible and liable for any activity that occurs under your username. You are responsible for keeping your password secure.
+The following terms and conditions govern all use of the WordPress.com website 
+and all content, services, and products available at or through the website, 
+including, but not limited to, 
+Jetpack ("Jetpack"), VaultPress ("VaultPress"), and WordPress.com VIP ("VIP Service"), 
+(taken together, our Services).
+Our Services are offered subject to your acceptance without modification of 
+all of the terms and conditions contained herein 
+and all other operating rules, policies 
+(including, without limitation, [Automattic's Privacy Policy](http://automattic.com/privacy/)) 
+and procedures that may be published from time to time by Automattic 
+(collectively, the "Agreement"). 
+You agree that we may automatically upgrade our Services, 
+and these terms will apply to any upgrades. 
+If you reside in the United States, your agreement is with Automattic Inc. (US),
+and if you reside outside of the United States, your agreement is with Aut O'Mattic Ltd. (Ireland)
+(each, "Automattic" or "we").
+Please read this Agreement carefully before accessing or using our Services. 
+By accessing or using any part of our services, 
+you agree to become bound by the terms and conditions of this agreement. 
+If you do not agree to all the terms and conditions of this agreement, 
+then you may not access or use any of our services. 
+If these terms and conditions are considered an offer by Automattic, 
+acceptance is expressly limited to these terms. 
+Our Services are not directed to children younger than 13, 
+and access and use of our Services is only offered to users 13 years of age or older. 
+If you are under 13 years old, please do not register to use our Services. 
+Any person who registers as a user or provides their personal information to our Services
+represents that they are 13 years of age or older. 
+Use of our Services requires a WordPress.com account. 
+You agree to provide us with complete and accurate information when you register for an account. 
+You will be solely responsible and liable for any activity that occurs under your username. 
+You are responsible for keeping your password secure.
 
 #### 1. WordPress.com.
 
-*   **Your WordPress.com Account and Website.** If you create a blog or website on WordPress.com, you are responsible for maintaining the security of your account and blog, and you are fully responsible for all activities that occur under the account and any other actions taken in connection with the blog. You must immediately notify Automattic of any unauthorized uses of your blog, your account, or any other breaches of security. Automattic will not be liable for any acts or omissions by you, including any damages of any kind incurred as a result of such acts or omissions.
-*   **Responsibility of Contributors.** If you operate a blog, comment on a blog, post material to WordPress.com, post links on WordPress.com, or otherwise make (or allow any third party to make) material available (any such material, "Content"), you are entirely responsible for the content of, and any harm resulting from, that Content. That is the case regardless of what form the Content takes, which includes, but is not limited to text, photo, video, audio, or code. By making Content available, you represent and warrant that your content does not violate these terms or the [User Guidelines](http://en.support.wordpress.com/user-guidelines/).By submitting Content to Automattic for inclusion on your website, you grant Automattic a world-wide, royalty-free, and non-exclusive license to reproduce, modify, adapt and publish the Content solely for the purpose of displaying, distributing, and promoting your blog. This license allows Automattic to make publicly-posted content available to third parties selected by Automattic (through the Automattic Firehose, for example) so that these third parties can analyze and distribute (but not publicly display) your content through their services. You also give other WordPress.com users permission to share your Content on other WordPress.com websites and add their own Content to it (aka to reblog your Content), so long as they use only a portion of your post and they give you credit as the original author by linking back to your website (the [reblogging function](http://en.support.wordpress.com/reblogs) on WordPress.com does this automatically!). If you delete Content, Automattic will use reasonable efforts to remove it from WordPress.com, but you acknowledge that caching or references to the Content may not be made immediately unavailable.Without limiting any of those representations or warranties, Automattic has the right (though not the obligation) to, in Automattic's sole discretion, (i) refuse or remove any content that, in Automattic's reasonable opinion, violates any Automattic policy or is in any way harmful or objectionable, or (ii) terminate or deny access to and use of WordPress.com to any individual or entity for any reason. Automattic will have no obligation to provide a refund of any amounts previously paid.
-*   **Advertisements.** Automattic reserves the right to display advertisements on your blog unless you have purchased an Ad-free Upgrade or a VIP Service account.
-*   **Attribution.** Automattic reserves the right to display attribution links such as 'Blog at WordPress.com,' theme author, and font attribution in your blog footer or toolbar. Footer credits and the WordPress.com toolbar may not be altered or removed regardless of upgrades purchased.
-*   **Friends of WP.com Themes.** By activating a partner theme from the Friends of WP.com section of our themes directory, you agree to that partner's terms of service. You can opt out of their terms of service at any time by de-activating a partner theme.
+*   **Your WordPress.com Account and Website.**
+If you create a blog or website on WordPress.com, 
+you are responsible for maintaining the security of your account and blog, 
+and you are fully responsible for all activities that occur under the account 
+and any other actions taken in connection with the blog. 
+You must immediately notify Automattic of any unauthorized uses of your blog, your account, 
+or any other breaches of security. 
+Automattic will not be liable for any acts or omissions by you, 
+including any damages of any kind incurred as a result of such acts or omissions.
+*   **Responsibility of Contributors.** 
+If you operate a blog, 
+comment on a blog, 
+post material to WordPress.com, 
+post links on WordPress.com, 
+or otherwise make (or allow any third party to make) material available (any such material, "Content"),
+you are entirely responsible for the content of, and any harm resulting from, that Content. 
+That is the case regardless of what form the Content takes, 
+which includes, but is not limited to text, photo, video, audio, or code. 
+By making Content available, 
+you represent and warrant that your content does not violate 
+these terms or the [User Guidelines](http://en.support.wordpress.com/user-guidelines/).By submitting Content to Automattic for inclusion on your website,
+you grant Automattic a world-wide, royalty-free, and non-exclusive license to
+reproduce, modify, adapt and publish the Content 
+solely for the purpose of displaying, distributing, and promoting your blog. 
+This license allows Automattic to make publicly-posted content available to
+third parties selected by Automattic (through the Automattic Firehose, for example) 
+so that these third parties can analyze and distribute (but not publicly display) 
+your content through their services. 
+You also give other WordPress.com users permission to 
+share your Content on other WordPress.com websites and add their own Content to it 
+(aka to reblog your Content),
+so long as they use only a portion of your post 
+and they give you credit as the original author by linking back to your website 
+(the [reblogging function](http://en.support.wordpress.com/reblogs) on WordPress.com does this automatically!). 
+If you delete Content, Automattic will use reasonable efforts to remove it from WordPress.com, 
+but you acknowledge that caching or references to the Content may not be made immediately unavailable.Without limiting any of those representations or warranties, 
+Automattic has the right (though not the obligation) to, in Automattic's sole discretion, 
+(i) refuse or remove any content that, in Automattic's reasonable opinion, 
+violates any Automattic policy or is in any way harmful or objectionable, or
+(ii) terminate or deny access to and use of WordPress.com to any individual or entity for any reason. 
+Automattic will have no obligation to provide a refund of any amounts previously paid.
+*   **Advertisements.** 
+Automattic reserves the right to display advertisements on your blog
+unless you have purchased an Ad-free Upgrade or a VIP Service account.
+*   **Attribution.** 
+Automattic reserves the right to display attribution links such as
+'Blog at WordPress.com,' theme author, and font attribution in your blog footer or toolbar. 
+Footer credits and the WordPress.com toolbar may not be altered or removed regardless of upgrades purchased.
+*   **Friends of WP.com Themes.** 
+By activating a partner theme from the Friends of WP.com section of our themes directory, 
+you agree to that partner's terms of service. 
+You can opt out of their terms of service at any time by de-activating a partner theme.
 *   **Payment and Renewal.**
-    *   **General Terms.** Optional paid services such as extra storage or domain purchases are available (any such services, an "Upgrade"). By selecting an Upgrade you agree to pay Automattic the monthly or annual subscription fees indicated for that service. Payments will be charged on a pre-pay basis on the day you sign up for an Upgrade and will cover the use of that service for a monthly or annual subscription period as indicated. You can read about our refund policy [here](https://en.support.wordpress.com/refunds/).
-    *   **Automatic Renewal.** Unless you notify Automattic before the end of the applicable subscription period that you want to cancel an Upgrade, your Upgrade subscription will automatically renew and you authorize us to collect the then-applicable annual or monthly subscription fee for such Upgrade (as well as any taxes) using any credit card or other payment mechanism we have on record for you. Upgrades can be canceled at any time in the Upgrades section of your website's dashboard.
-    *   **VIP Service. **VIP Hosting/Support and VIP Support services are provided by Automattic under the terms and conditions for each such service, which are located at [vip.wordpress.com/hosting-tos](http://vip.wordpress.com/hosting-tos/) and [vip.wordpress.com/support-tos](http://vip.wordpress.com/support-tos/), respectively. By signing up for a VIP Hosting/Support or VIP Support services account, you agree to abide by such terms and conditions.
+    *   **General Terms.**
+    Optional paid services such as extra storage or domain purchases are available 
+(any such services, an "Upgrade"). 
+By selecting an Upgrade you agree to pay Automattic 
+the monthly or annual subscription fees indicated for that service. 
+Payments will be charged on a pre-pay basis on the day you sign up for an Upgrade 
+and will cover the use of that service for a monthly or annual subscription period as indicated. 
+You can read about our refund policy [here](https://en.support.wordpress.com/refunds/).
+    *   **Automatic Renewal.** 
+    Unless you notify Automattic before the end of the applicable subscription period 
+that you want to cancel an Upgrade, 
+your Upgrade subscription will automatically renew and you authorize us to
+collect the then-applicable annual or monthly subscription fee for such Upgrade (as well as any taxes) 
+using any credit card or other payment mechanism we have on record for you. 
+Upgrades can be canceled at any time in the Upgrades section of your website's dashboard.
+    *   **VIP Service. **VIP Hosting/Support and VIP Support services are provided by Automattic under
+    the terms and conditions for each such service, 
+which are located at [vip.wordpress.com/hosting-tos](http://vip.wordpress.com/hosting-tos/) 
+and [vip.wordpress.com/support-tos](http://vip.wordpress.com/support-tos/), respectively. 
+By signing up for a VIP Hosting/Support or VIP Support services account, 
+you agree to abide by such terms and conditions.
 
 #### 2. VaultPress.
 
-*   **Description.** VaultPress is a subscription-based security and backup service for self-hosted WordPress websites.
-*   **VaultPress Content.** VaultPress will backup your WordPress content (e.g., your WordPress database, plugins, themes, and uploads, as well as some additional files, as described [here](http://help.vaultpress.com/get-to-know/)) ("VaultPress Content"). You can view the Content that VaultPress backs up via your [dashboard](https://dashboard.vaultpress.com/). You're fully responsible for your VaultPress Content. It's your responsibility to ensure that your website's Content abides by applicable laws and by these Terms. We don't actively review the VaultPress Content.
-*   **Access.** If you lose access to your WordPress.com account, you may not be able to access your backed up VaultPress Content.
-*   **License.** By using VaultPress, you grant us access to your website's servers for the purpose of backing up and securing your VaultPress Content, and restoring files and database information (which may include access details for multiple servers or accounts for each website that we backup). In order to address security vulnerabilities, we may push an upgrade to your site, or we may access your site to remove malicious code. We may also scan VaultPress Content, and compile aggregated/anonymized statistics for our internal use to optimize the performance of the VaultPress service. You also grant us a worldwide, royalty-free, and non-exclusive license to copy and store your VaultPress Content, to the extent necessary to operate the VaultPress service. These Terms don't give us any rights in your VaultPress Content, beyond those we need to operate VaultPress. You own your VaultPress Content.
+*   **Description.** 
+VaultPress is a subscription-based security and backup service for self-hosted WordPress websites.
+*   **VaultPress Content.** 
+VaultPress will backup your WordPress content
+(e.g., your WordPress database, plugins, themes, and uploads, 
+as well as some additional files, as described [here](http://help.vaultpress.com/get-to-know/)) 
+("VaultPress Content"). 
+You can view the Content that VaultPress backs up via your [dashboard](https://dashboard.vaultpress.com/). 
+You're fully responsible for your VaultPress Content. 
+It's your responsibility to ensure that your website's Content abides by applicable laws and by these Terms. 
+We don't actively review the VaultPress Content.
+*   **Access.**
+If you lose access to your WordPress.com account, 
+you may not be able to access your backed up VaultPress Content.
+*   **License.**
+By using VaultPress, you grant us access to your website's servers for the purpose of
+backing up and securing your VaultPress Content, 
+and restoring files and database information 
+(which may include access details for multiple servers or accounts for each website that we backup).
+In order to address security vulnerabilities, 
+we may push an upgrade to your site, or we may access your site to remove malicious code. 
+We may also scan VaultPress Content, 
+and compile aggregated/anonymized statistics for our internal use 
+to optimize the performance of the VaultPress service. 
+You also grant us a worldwide, royalty-free, and non-exclusive license to 
+copy and store your VaultPress Content, to the extent necessary to operate the VaultPress service. 
+These Terms don't give us any rights in your VaultPress Content, beyond those we need to operate VaultPress. 
+You own your VaultPress Content.
 *   **Prohibited Uses.** When using VaultPress, you agree not to:
     *   Publish material or engage in activity that is illegal under applicable law.
     *   Use VaultPress to overburden Automattic's systems, as determined by us in our sole discretion.
@@ -38,30 +177,103 @@ The following terms and conditions govern all use of the WordPress.com website a
     *   Interfere with, disrupt, or attack any service or network.
     *   Distribute material that is or enables malware, spyware, adware, or other malicious code.
 
-*   **Payment, Renewal and Refunds.** VaultPress offers different [levels of service](https://vaultpress.com/plans/). By signing up for a particular level of service, you agree to pay VaultPress the applicable subscription fees. Unless you notify us before the end of your subscription period that you no longer wish to run VaultPress, your subscription will renew automatically. If we change pricing for a service to which you're subscribed, we will notify you before your subscription is set to renew. You authorize us to charge any then-applicable fees to your credit card or other payment method we have on file for you. We offer refunds up to thirty (30) days after payment. Payment failures will result in the cancellation of your VaultPress plan. Each WordPress website requires a separate subscription to run VaultPress.
-*   **Cancellation.** If you cancel your subscription to VaultPress, we will queue your backed-up VaultPress Content for deletion.
+*   **Payment, Renewal and Refunds.** 
+VaultPress offers different [levels of service](https://vaultpress.com/plans/).
+By signing up for a particular level of service, 
+you agree to pay VaultPress the applicable subscription fees. 
+Unless you notify us before the end of your subscription period that you no longer wish to run VaultPress, 
+your subscription will renew automatically. 
+If we change pricing for a service to which you're subscribed, 
+we will notify you before your subscription is set to renew. 
+You authorize us to charge any then-applicable fees to 
+your credit card or other payment method we have on file for you. 
+We offer refunds up to thirty (30) days after payment. 
+Payment failures will result in the cancellation of your VaultPress plan.
+Each WordPress website requires a separate subscription to run VaultPress.
+*   **Cancellation.** 
+If you cancel your subscription to VaultPress, we will queue your backed-up VaultPress Content for deletion.
 
 #### 3. Firehose.
 
-*   **Fees; Payment.** By signing up for the WordPress.com Firehose you agree to pay Automattic the specified monthly fees in exchange for access to the feeds. Applicable fees will be invoiced starting from the day your access is established and in advance of using such services. Automattic reserves the right to change the payment terms and fees upon thirty (30) days prior written notice to you. Firehose access can be canceled by you at anytime on 30 days written notice to Automattic.
-*   **Permitted Use.** You may use the WordPress.com Firehose to develop a product or service that searches, displays, analyzes, retrieves, and views information available on WordPress.com. You may also use the WordPress.com name or logos and other brand elements that Automattic makes available in order to identify the source of the information.
-*   **Restricted Use.** You may not use the WordPress.com Firehose to substantially replicate products or services offered by Automattic, including the republication of WordPress.com content or the creation of a separate publishing platform. If Automattic believes, in its sole discretion, that you have violated or attempted to violate these conditions or the spirit of these terms, your ability to use and access the WordPress.com Firehose may be temporarily or permanently revoked, with or without notice.
+*   **Fees; Payment.**
+By signing up for the WordPress.com Firehose 
+you agree to pay Automattic the specified monthly fees in exchange for access to the feeds. 
+Applicable fees will be invoiced starting from the day your access is established 
+and in advance of using such services. 
+Automattic reserves the right to change the payment terms and fees upon 
+thirty (30) days prior written notice to you. 
+Firehose access can be canceled by you at anytime on 30 days written notice to Automattic.
+*   **Permitted Use.**
+You may use the WordPress.com Firehose to develop a product or service that 
+searches, displays, analyzes, retrieves, and views information available on WordPress.com. 
+You may also use the WordPress.com name or logos and other brand elements that Automattic makes available 
+in order to identify the source of the information.
+*   **Restricted Use.**
+You may not use the WordPress.com Firehose to substantially replicate products or services offered by Automattic,
+including the republication of WordPress.com content or the creation of a separate publishing platform. 
+If Automattic believes, in its sole discretion, that
+you have violated or attempted to violate these conditions or the spirit of these terms, 
+your ability to use and access the WordPress.com Firehose may be temporarily or permanently revoked, 
+with or without notice.
 
 #### 4. Responsibility of Visitors.
 
-Automattic has not reviewed, and cannot review, all of the material, including computer software, posted to our Services, and cannot therefore be responsible for that material's content, use or effects. By operating our Services, Automattic does not represent or imply that it endorses the material there posted, or that it believes such material to be accurate, useful, or non-harmful. You are responsible for taking precautions as necessary to protect yourself and your computer systems from viruses, worms, Trojan horses, and other harmful or destructive content. Our Services may contain content that is offensive, indecent, or otherwise objectionable, as well as content containing technical inaccuracies, typographical mistakes, and other errors. Our Services may also contain material that violates the privacy or publicity rights, or infringes the intellectual property and other proprietary rights, of third parties, or the downloading, copying or use of which is subject to additional terms and conditions, stated or unstated. Automattic disclaims any responsibility for any harm resulting from the use by visitors of our Services, or from any downloading by those visitors of content there posted.
+Automattic has not reviewed, and cannot review, 
+all of the material, including computer software, posted to our Services, 
+and cannot therefore be responsible for that material's content, use or effects. 
+By operating our Services, 
+Automattic does not represent or imply that it endorses the material there posted, 
+or that it believes such material to be accurate, useful, or non-harmful. 
+You are responsible for taking precautions as necessary to protect yourself and your computer systems from
+viruses, worms, Trojan horses, and other harmful or destructive content. 
+Our Services may contain content that is offensive, indecent, or otherwise objectionable,
+as well as content containing technical inaccuracies, typographical mistakes, and other errors.
+Our Services may also contain material that
+violates the privacy or publicity rights,
+or infringes the intellectual property and other proprietary rights,
+of third parties,
+or the downloading, copying or use of which is subject to additional terms and conditions, stated or unstated.
+Automattic disclaims any responsibility for any harm resulting
+from the use by visitors of our Services,
+or from any downloading by those visitors of content there posted.
 
 #### 5. Content Posted on Other Websites.
 
-We have not reviewed, and cannot review, all of the material, including computer software, made available through the websites and webpages to which WordPress.com links, and that link to WordPress.com. Automattic does not have any control over those non-WordPress.com websites, and is not responsible for their contents or their use. By linking to a non-WordPress.com website, Automattic does not represent or imply that it endorses such website. You are responsible for taking precautions as necessary to protect yourself and your computer systems from viruses, worms, Trojan horses, and other harmful or destructive content. Automattic disclaims any responsibility for any harm resulting from your use of non-WordPress.com websites and webpages.
+We have not reviewed, and cannot review,
+all of the material, including computer software, made available through
+the websites and webpages to which WordPress.com links, and that link to WordPress.com.
+Automattic does not have any control over those non-WordPress.com websites,
+and is not responsible for their contents or their use.
+By linking to a non-WordPress.com website, Automattic does not represent or imply that it endorses such website.
+You are responsible for taking precautions as necessary to protect yourself and your computer systems from
+viruses, worms, Trojan horses, and other harmful or destructive content.
+Automattic disclaims any responsibility for any harm resulting from
+your use of non-WordPress.com websites and webpages.
 
 #### 6. Copyright Infringement and DMCA Policy.
 
-As Automattic asks others to respect its intellectual property rights, it respects the intellectual property rights of others. If you believe that material located on or linked to by WordPress.com violates your copyright, you are encouraged to notify Automattic in accordance with [Automattic's Digital Millennium Copyright Act ("DMCA") Policy](http://automattic.com/dmca-notice/). Automattic will respond to all such notices, including as required or appropriate by removing the infringing material or disabling all links to the infringing material. Automattic will terminate a visitor's access to and use of the Website if, under appropriate circumstances, the visitor is determined to be a repeat infringer of the copyrights or other intellectual property rights of Automattic or others. In the case of such termination, Automattic will have no obligation to provide a refund of any amounts previously paid to Automattic.
+As Automattic asks others to respect its intellectual property rights,
+it respects the intellectual property rights of others.
+If you believe that material located on or linked to by WordPress.com violates your copyright,
+you are encouraged to notify Automattic in accordance with
+[Automattic's Digital Millennium Copyright Act ("DMCA") Policy](http://automattic.com/dmca-notice/).
+Automattic will respond to all such notices,
+including as required or appropriate by removing the infringing material
+or disabling all links to the infringing material.
+Automattic will terminate a visitor's access to and use of the Website if, under appropriate circumstances,
+the visitor is determined to be a repeat infringer of
+the copyrights or other intellectual property rights of Automattic or others.
+In the case of such termination,
+Automattic will have no obligation to provide a refund of any amounts previously paid to Automattic.
 
 #### 7. Intellectual Property.
 
-This Agreement does not transfer from Automattic to you any Automattic or third party intellectual property, and all right, title, and interest in and to such property will remain (as between the parties) solely with Automattic. Automattic, WordPress, WordPress.com, the WordPress.com logo, and all other trademarks, service marks, graphics and logos used in connection with WordPress.com or our Services, are trademarks or registered trademarks of Automattic or Automattic's licensors. Other trademarks, service marks, graphics and logos used in connection with our Services may be the trademarks of other third parties. Your use of our Services grants you no right or license to reproduce or otherwise use any Automattic or third-party trademarks.
+This Agreement does not transfer from Automattic to you any Automattic or third party intellectual property,
+and all right, title, and interest in and to such property will remain (as between the parties)
+solely with Automattic.
+Automattic, WordPress, WordPress.com, the WordPress.com logo, and all other
+trademarks, service marks, graphics and logos used in connection with WordPress.com or our Services,
+are trademarks or registered trademarks of Automattic or Automattic's licensors. Other trademarks, service marks, graphics and logos used in connection with our Services may be the trademarks of other third parties. Your use of our Services grants you no right or license to reproduce or otherwise use any Automattic or third-party trademarks.
 
 #### 8. Domain Names.
 

--- a/Terms of Service/WordPress.com/EN-Terms-of-Service.md
+++ b/Terms of Service/WordPress.com/EN-Terms-of-Service.md
@@ -17,7 +17,7 @@ appear on your website.
 If you find a WordPress.com website that you believe violates these Terms of Service, 
 please [visit our dispute resolution & reporting page](http://en.support.wordpress.com/disputes/).
 
-We also have additional services and products designed to make the web a betterchange place
+We also have additional services and products designed to make the web a better place
 like WordPress.com VIP, WooCommerce, Longreads, VaultPress, Akismet, and Jetpack.
 
 (We've made the below Terms of Service available under a 
@@ -69,7 +69,7 @@ If you create a blog or website on WordPress.com,
 you are responsible for maintaining the security of your account and blog, 
 and you are fully responsible for all activities that occur under the account 
 and any other actions taken in connection with the blog. 
-You must immediately notify Automattic of any unauthorized uses of your blog, your account, 
+You must immediately notify Automattic of any unauthorized uses of your blog or your account, 
 or any other breaches of security. 
 Automattic will not be liable for any acts or omissions by you, 
 including any damages of any kind incurred as a result of such acts or omissions.
@@ -84,7 +84,8 @@ That is the case regardless of what form the Content takes,
 which includes, but is not limited to text, photo, video, audio, or code. 
 By making Content available, 
 you represent and warrant that your content does not violate 
-these terms or the [User Guidelines](http://en.support.wordpress.com/user-guidelines/).By submitting Content to Automattic for inclusion on your website,
+these terms or the [User Guidelines](http://en.support.wordpress.com/user-guidelines/).
+By submitting Content to Automattic for inclusion on your website,
 you grant Automattic a world-wide, royalty-free, and non-exclusive license to
 reproduce, modify, adapt and publish the Content 
 solely for the purpose of displaying, distributing, and promoting your blog. 
@@ -99,7 +100,8 @@ so long as they use only a portion of your post
 and they give you credit as the original author by linking back to your website 
 (the [reblogging function](http://en.support.wordpress.com/reblogs) on WordPress.com does this automatically!). 
 If you delete Content, Automattic will use reasonable efforts to remove it from WordPress.com, 
-but you acknowledge that caching or references to the Content may not be made immediately unavailable.Without limiting any of those representations or warranties, 
+but you acknowledge that caching or references to the Content may not be made immediately unavailable.
+Without limiting any of those representations or warranties, 
 Automattic has the right (though not the obligation) to, in Automattic's sole discretion, 
 (i) refuse or remove any content that, in Automattic's reasonable opinion, 
 violates any Automattic policy or is in any way harmful or objectionable, or
@@ -132,7 +134,8 @@ your Upgrade subscription will automatically renew and you authorize us to
 collect the then-applicable annual or monthly subscription fee for such Upgrade (as well as any taxes) 
 using any credit card or other payment mechanism we have on record for you. 
 Upgrades can be canceled at any time in the Upgrades section of your website's dashboard.
-    *   **VIP Service. **VIP Hosting/Support and VIP Support services are provided by Automattic under
+    *   **VIP Service.**
+    VIP Hosting/Support and VIP Support services are provided by Automattic under
     the terms and conditions for each such service, 
 which are located at [vip.wordpress.com/hosting-tos](http://vip.wordpress.com/hosting-tos/) 
 and [vip.wordpress.com/support-tos](http://vip.wordpress.com/support-tos/), respectively. 
@@ -176,7 +179,6 @@ You own your VaultPress Content.
     *   Send spam or bulk unsolicited messages.
     *   Interfere with, disrupt, or attack any service or network.
     *   Distribute material that is or enables malware, spyware, adware, or other malicious code.
-
 *   **Payment, Renewal and Refunds.** 
 VaultPress offers different [levels of service](https://vaultpress.com/plans/).
 By signing up for a particular level of service, 

--- a/Terms of Service/WordPress.com/EN-Terms-of-Service.md
+++ b/Terms of Service/WordPress.com/EN-Terms-of-Service.md
@@ -273,51 +273,151 @@ and all right, title, and interest in and to such property will remain (as betwe
 solely with Automattic.
 Automattic, WordPress, WordPress.com, the WordPress.com logo, and all other
 trademarks, service marks, graphics and logos used in connection with WordPress.com or our Services,
-are trademarks or registered trademarks of Automattic or Automattic's licensors. Other trademarks, service marks, graphics and logos used in connection with our Services may be the trademarks of other third parties. Your use of our Services grants you no right or license to reproduce or otherwise use any Automattic or third-party trademarks.
+are trademarks or registered trademarks of Automattic or Automattic's licensors.
+Other trademarks, service marks, graphics and logos used in connection with our Services
+may be the trademarks of other third parties.
+Your use of our Services grants you no right or license to reproduce or otherwise use
+any Automattic or third-party trademarks.
 
 #### 8. Domain Names.
 
-If you are registering a domain name, using or transferring a previously registered domain name, you acknowledge and agree that use of the domain name is also subject to the policies of the Internet Corporation for Assigned Names and Numbers ("ICANN") and the [Domain Name Registration and Customer Service Agreement](http://www.secureserver.net/agreements/showdoc.aspx?pageid=7959&prog_id=391143).
+If you are registering a domain name, using or transferring a previously registered domain name,
+you acknowledge and agree that use of the domain name is also subject to the policies of
+the Internet Corporation for Assigned Names and Numbers ("ICANN")
+and the [Domain Name Registration and Customer Service Agreement](http://www.secureserver.net/agreements/showdoc.aspx?pageid=7959&prog_id=391143).
 
 #### 9. Google Apps.
 
-If you purchase a Google Apps subscription, this section applies. Google Apps are provided by Google, and your use of Google Apps is subject to Google's [Terms of Use](https://www.google.com/apps/intl/en/terms/reseller_premier_terms.html) for the services, which you'll accept prior to using Google Apps for the first time. Automattic is an authorized reseller of Google Apps, makes no warranties about the services provided by Google, and disclaims Google's liability for any damages arising from our distribution and resale of their services. Google will provide technical support for its services, per its [Technical Support Services Guidelines](https://www.google.com/apps/intl/en/terms/tssg.html). If you're a business and purchase Google Apps for your WordPress.com website, you represent that you have 749 or fewer staff members.
+If you purchase a Google Apps subscription, this section applies.
+Google Apps are provided by Google, and your use of Google Apps is subject to
+Google's [Terms of Use](https://www.google.com/apps/intl/en/terms/reseller_premier_terms.html) for the services,
+which you'll accept prior to using Google Apps for the first time.
+Automattic is an authorized reseller of Google Apps,
+makes no warranties about the services provided by Google,
+and disclaims Google's liability for any damages arising from our distribution and resale of their services.
+Google will provide technical support for its services,
+per its [Technical Support Services Guidelines](https://www.google.com/apps/intl/en/terms/tssg.html).
+If you're a business and purchase Google Apps for your WordPress.com website,
+you represent that you have 749 or fewer staff members.
 
 #### 10. Changes.
 
-We are constantly updating our Services, and that means sometimes we have to change the legal terms under which our Services are offered. If we make changes that are material, we will let you know by posting on one of our blogs, or by sending you an email or other communication before the changes take effect. The notice will designate a reasonable period of time after which the new terms will take effect. If you disagree with our changes, then you should stop using our Services within the designated notice period. Your continued use of our Services will be subject to the new terms. However, any dispute that arose before the changes shall be governed by the Terms (including the binding individual arbitration clause) that were in place when the dispute arose.
+We are constantly updating our Services,
+and that means sometimes we have to change the legal terms under which our Services are offered.
+If we make changes that are material, we will let you know by
+posting on one of our blogs, or by sending you an email or other communication before the changes take effect.
+The notice will designate a reasonable period of time after which the new terms will take effect.
+If you disagree with our changes, then you should stop using our Services within the designated notice period.
+Your continued use of our Services will be subject to the new terms.
+However, any dispute that arose before the changes shall be governed by the Terms
+(including the binding individual arbitration clause)
+that were in place when the dispute arose.
 
 #### 11. Termination.
 
-Automattic may terminate your access to all or any part of our Services at any time, with or without cause, with or without notice, effective immediately. If you wish to terminate this Agreement or your WordPress.com account (if you have one), you may simply discontinue using our Services. All provisions of this Agreement which by their nature should survive termination shall survive termination, including, without limitation, ownership provisions, warranty disclaimers, indemnity and limitations of liability.
+Automattic may terminate your access to all or any part of our Services at any time,
+with or without cause, with or without notice, effective immediately.
+If you wish to terminate this Agreement or your WordPress.com account (if you have one),
+you may simply discontinue using our Services.
+All provisions of this Agreement which by their nature should survive termination shall survive termination,
+including, without limitation,
+ownership provisions,
+warranty disclaimers,
+indemnity and
+limitations of liability.
 
 #### 12. Disclaimer of Warranties.
 
-Our Services are provided "as is." Automattic and its suppliers and licensors hereby disclaim all warranties of any kind, express or implied, including, without limitation, the warranties of merchantability, fitness for a particular purpose and non-infringement. Neither Automattic nor its suppliers and licensors, makes any warranty that our Services will be error free or that access thereto will be continuous or uninterrupted. If you're actually reading this, [here's a treat](http://wordpress.com/tos/treat/). You understand that you download from, or otherwise obtain content or services through, our Services at your own discretion and risk.
+Our Services are provided "as is."
+Automattic and its suppliers and licensors hereby disclaim all warranties of any kind, express or implied,
+including, without limitation, the warranties of
+merchantability, fitness for a particular purpose and non-infringement.
+Neither Automattic nor its suppliers and licensors, makes any warranty
+that our Services will be error free or that access thereto will be continuous or uninterrupted.
+If you're actually reading this, [here's a treat](http://wordpress.com/tos/treat/).
+You understand that you download from, or otherwise obtain content or services through, our Services
+at your own discretion and risk.
 
 #### 13. Limitation of Liability.
 
-In no event will Automattic, or its suppliers or licensors, be liable with respect to any subject matter of this Agreement under any contract, negligence, strict liability or other legal or equitable theory for: (i) any special, incidental or consequential damages; (ii) the cost of procurement for substitute products or services; (iii) for interruption of use or loss or corruption of data; or (iv) for any amounts that exceed the fees paid by you to Automattic under this agreement during the twelve (12) month period prior to the cause of action. Automattic shall have no liability for any failure or delay due to matters beyond their reasonable control. The foregoing shall not apply to the extent prohibited by applicable law.
+In no event will Automattic, or its suppliers or licensors,
+be liable with respect to any subject matter of this Agreement under any
+contract, negligence, strict liability or other legal or equitable theory for:
+(i) any special, incidental or consequential damages;
+(ii) the cost of procurement for substitute products or services;
+(iii) for interruption of use or loss or corruption of data; or
+(iv) for any amounts that exceed the fees paid by you to Automattic under this agreement during the
+twelve (12) month period prior to the cause of action.
+Automattic shall have no liability for any failure or delay due to matters beyond their reasonable control.
+The foregoing shall not apply to the extent prohibited by applicable law.
 
 #### 14. General Representation and Warranty.
 
-You represent and warrant that (i) your use of our Services will be in strict accordance with the Automattic Privacy Policy, with this Agreement, and with all applicable laws and regulations (including without limitation any local laws or regulations in your country, state, city, or other governmental area, regarding online conduct and acceptable content, and including all applicable laws regarding the transmission of technical data exported from the United States or the country in which you reside) and (ii) your use of our Services will not infringe or misappropriate the intellectual property rights of any third party.
+You represent and warrant that
+(i) your use of our Services will be in strict accordance
+with the Automattic Privacy Policy,
+with this Agreement,
+and with all applicable laws and regulations
+(including without limitation any local laws or regulations
+in your country, state, city, or other governmental area,
+regarding online conduct and acceptable content,
+and including all applicable laws regarding the transmission of technical data exported from
+the United States or the country in which you reside) and
+(ii) your use of our Services will not infringe or misappropriate
+the intellectual property rights of any third party.
 
 #### 15. US Economic Sanctions.
 
-You expressly represent and warrant that your use of our Services and or associated services and products is not contrary to applicable U.S. Sanctions. Such use is prohibited, and Automattic reserve the right to terminate accounts or access of those in the event of a breach of this condition.
+You expressly represent and warrant that your use of our Services and or associated services and products
+is not contrary to applicable U.S. Sanctions.
+Such use is prohibited,
+and Automattic reserve the right to terminate accounts or access of those
+in the event of a breach of this condition.
 
 #### 16. Indemnification.
 
-You agree to indemnify and hold harmless Automattic, its contractors, and its licensors, and their respective directors, officers, employees, and agents from and against any and all claims and expenses, including attorneys' fees, arising out of your use of our Services, including but not limited to your violation of this Agreement.
+You agree to indemnify and hold harmless
+Automattic, its contractors, and its licensors, and their respective
+directors, officers, employees, and agents
+from and against any and all claims and expenses, including attorneys' fees,
+arising out of your use of our Services, including but not limited to your violation of this Agreement.
 
 #### 17. Translation.
 
-These Terms of Service were originally written in English (US). We may translate these terms into other languages. In the event of a conflict between a translated version of these Terms of Service and the English version, the English version will control.
+These Terms of Service were originally written in English (US).
+We may translate these terms into other languages.
+In the event of a conflict between a translated version of these Terms of Service and the English version,
+the English version will control.
 
 #### 18. Miscellaneous.
 
-This Agreement constitutes the entire agreement between Automattic and you concerning the subject matter hereof, and they may only be modified by a written amendment signed by an authorized executive of Automattic, or by the posting by Automattic of a revised version. Except to the extent applicable law, if any, provides otherwise, this Agreement, any access to or use of our Services will be governed by the laws of the state of California, U.S.A., excluding its conflict of law provisions, and the proper venue for any disputes arising out of or relating to any of the same will be the state and federal courts located in San Francisco County, California. Except for claims for injunctive or equitable relief or claims regarding intellectual property rights (which may be brought in any competent court without the posting of a bond), any dispute arising under this Agreement shall be finally settled in accordance with the Comprehensive Arbitration Rules of the Judicial Arbitration and Mediation Service, Inc. ("JAMS") by three arbitrators appointed in accordance with such Rules. The arbitration shall take place in San Francisco, California, in the English language and the arbitral decision may be enforced in any court. The prevailing party in any action or proceeding to enforce this Agreement shall be entitled to costs and attorneys' fees. If any part of this Agreement is held invalid or unenforceable, that part will be construed to reflect the parties' original intent, and the remaining portions will remain in full force and effect. A waiver by either party of any term or condition of this Agreement or any breach thereof, in any one instance, will not waive such term or condition or any subsequent breach thereof. You may assign your rights under this Agreement to any party that consents to, and agrees to be bound by, its terms and conditions; Automattic may assign its rights under this Agreement without condition. This Agreement will be binding upon and will inure to the benefit of the parties, their successors and permitted assigns. 
+This Agreement constitutes the entire agreement between Automattic and you concerning the subject matter hereof,
+and they may only be modified by a written amendment signed by an authorized executive of Automattic,
+or by the posting by Automattic of a revised version.
+Except to the extent applicable law, if any, provides otherwise,
+this Agreement, any access to or use of our Services
+will be governed by the laws of the state of California, U.S.A., excluding its conflict of law provisions,
+and the proper venue for any disputes arising out of or relating to any of the same will be the
+state and federal courts located in San Francisco County, California.
+Except for claims for injunctive or equitable relief or claims regarding intellectual property rights
+(which may be brought in any competent court without the posting of a bond),
+any dispute arising under this Agreement shall be finally settled in accordance with
+the Comprehensive Arbitration Rules of the Judicial Arbitration and Mediation Service, Inc. ("JAMS")
+by three arbitrators appointed in accordance with such Rules.
+The arbitration shall take place in San Francisco, California, in the English language
+and the arbitral decision may be enforced in any court.
+The prevailing party in any action or proceeding to enforce this Agreement shall be entitled to
+costs and attorneys' fees.
+If any part of this Agreement is held invalid or unenforceable,
+that part will be construed to reflect the parties' original intent,
+and the remaining portions will remain in full force and effect.
+A waiver by either party of any term or condition of this Agreement or any breach thereof, in any one instance,
+will not waive such term or condition or any subsequent breach thereof.
+You may assign your rights under this Agreement to any party that
+consents to, and agrees to be bound by, its terms and conditions;
+Automattic may assign its rights under this Agreement without condition.
+This Agreement will be binding upon and will inure to the benefit of
+the parties, their successors and permitted assigns. 
 
 [Print friendly version](https://wordpress.com/2015/09/wpcomtos.pdf)  
 [Change Log](http://wordpress.com/tos-change-log)


### PR DESCRIPTION
Add linebreaks so that future diffs are more informative than [this](https://github.com/Automattic/legalmattic/commit/00f0934a513ce47160ac9c519396681c85b08bde#diff-8c763ba3f2c4343589f0ed049fe0b69d), and then fix a few typos.