### PR TITLE
Update automattic.com to use HTTPS

### DIFF
--- a/Terms of Service/WordPress.com/EN-Terms-of-Service.md
+++ b/Terms of Service/WordPress.com/EN-Terms-of-Service.md
@@ -4,7 +4,7 @@ Terms of Service
 _Last Updated: June 25, 2021_
 
 ## The Gist
-We (the [folks at Automattic](http://automattic.com/about/)) are on a mission to make the web a better place. We hope you love our products and services — from website publishing tools to ecommerce solutions to security backup systems to management tools for distributed companies to the next great idea that we haven’t even thought of yet — as much as we love creating them.
+We (the [folks at Automattic](https://automattic.com/about/)) are on a mission to make the web a better place. We hope you love our products and services — from website publishing tools to ecommerce solutions to security backup systems to management tools for distributed companies to the next great idea that we haven’t even thought of yet — as much as we love creating them.
 These Terms of Service (“Terms”) describe our commitments to you, and your rights and responsibilities when using our services. Please read them carefully and reach out to us if you have any questions. **These Terms include a mandatory arbitration provision in Section 16. If you don’t agree to these Terms, don’t use our services.**
 We’ve made these Terms available under a [Creative Commons Sharealike license](https://creativecommons.org/licenses/by-sa/4.0/), which means that you’re more than welcome to copy them, adapt them, and repurpose them for your own use. Just make sure to revise them so that your Terms of Service reflect your actual practices. Also, if you do use these Terms, we’d appreciate a credit and link to Automattic somewhere on your website. You can grab a copy of these Terms and other legal documents on [GitHub](https://github.com/Automattic/legalmattic).
 ## Terms of Service


### PR DESCRIPTION
On automattic.com any non-HTTPS requests are redirected to the HTTPS version.  Because of that, the link to http://automattic.com/about/ is slower than it needs to be.  Updating the link to use https://automattic.com/about/ is both more correct and a faster experience for those that click on it.