### PR TITLE
Update name of WC Shipping and WC Tax in ToS

### DIFF
--- a/Terms of Service/WordPress.com/EN-Terms-of-Service.md
+++ b/Terms of Service/WordPress.com/EN-Terms-of-Service.md
@@ -40,7 +40,7 @@ Please see below to determine which entity your Agreement is with, which depends
 
 **Woo Services**
 
-*Woo services includes WooCommerce, WooPayments, Woo Shipping, Woo Tax, MailPoet, and other products or services available at WooCommerce.com. (Please note that for the use of Third-Party Services — as defined below — additional terms may govern).*
+*Woo services includes WooCommerce, WooPayments, WooCommerce Shipping, WooCommerce Tax, MailPoet, and other products or services available at WooCommerce.com. (Please note that for the use of Third-Party Services — as defined below — additional terms may govern).*
 
 -   If you reside outside of the Designated Countries: WooCommerce, Inc.
 -   If you reside in the Designated Countries: WooCommerce Ireland Ltd.


### PR DESCRIPTION
WooCommerce Shipping and WooCommerce Tax was originally planned to be called "Woo Shipping" and "Woo Tax" but was "renamed" when we reverted the Woo <> WooCommerce rebrand for the open source platform.

I don't consider this critical since the `... or other services available at WooCommerce.com...` section still covers it, but it will help merchants find the section if they look up our ToS and do a browser-page search for the plugins.