### PR TITLE
Update Privacy Policy to include company contact details 

### DIFF
--- a/Privacy-Policy.md
+++ b/Privacy-Policy.md
@@ -180,6 +180,12 @@ If you are located in a country that falls under the scope of the GDPR, data pro
 
 You also have the right to make a complaint to a government supervisory authority.
 
+If you have questions or concerns about how we handle your personal data, you can contact our Data Protection Officer at:
+
+[INSERT DPO NAME]
+[INSERT DPO EMAIL ADDRESS]
+[INSERT DPO MAILING ADDRESS]
+
 #### *US Privacy Laws*
 
 Laws in some US states require us to provide residents with additional information about the categories of personal information we collect and share, where we get that personal information, and how and why we use it. You'll find that information in this section (if you are a California resident, please note that this is the Notice at Collection we are required to provide you under California law).


### PR DESCRIPTION
This pull request proposes a small update to privacy-policy.md to better align the template with [GDPR Article 13(1)(a)–(b)](https://gdpr.eu/article-13-personal-data-collected/), which requires providing contact details for the data controller and/or the Data Protection Officer. Even when an organization does not formally name either, GDPR still requires a clear and effective contact point for privacy-related inquiries. 

The change updates the template to prompt companies using it (for example, [404 Media](https://www.404media.co/privacy-policy/)) to include this information explicitly. This helps reduce ambiguity, supports data subject rights, and improves baseline GDPR compliance.