### PR TITLE
Restrict new issues and PRs to Automattic team members

### DIFF
--- a/.github/workflows/renew-interaction-limits.yml
+++ b/.github/workflows/renew-interaction-limits.yml
@@ -1,0 +1,36 @@
+name: Renew interaction limit
+
+# Refreshes the repository's "collaborators_only" interaction limit
+# before its 6-month expiry runs out. Paired with restrict-contributions.yml:
+# this prevents non-Automattic-org users from opening issues/PRs at all,
+# while restrict-contributions.yml auto-closes anything that slips through
+# (e.g. if this job is ever paused or fails).
+
+on:
+  schedule:
+    # 1st of every month at 00:00 UTC
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
+
+permissions:
+  administration: write
+
+jobs:
+  renew:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            await github.request('PUT /repos/{owner}/{repo}/interaction-limits', {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              limit: 'collaborators_only',
+              expiry: 'six_months',
+            });
+
+            const { data } = await github.request(
+              'GET /repos/{owner}/{repo}/interaction-limits',
+              { owner: context.repo.owner, repo: context.repo.repo }
+            );
+            core.info(`Interaction limit: ${data.limit} (expires ${data.expires_at})`);

--- a/.github/workflows/restrict-contributions.yml
+++ b/.github/workflows/restrict-contributions.yml
@@ -1,0 +1,54 @@
+name: Restrict contributions to Automattic team
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  close-non-member:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.sender.type != 'Bot' &&
+      !contains(fromJSON('["MEMBER", "OWNER", "COLLABORATOR"]'),
+        github.event.pull_request.author_association || github.event.issue.author_association)
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const isPR = !!context.payload.pull_request;
+            const number = isPR
+              ? context.payload.pull_request.number
+              : context.payload.issue.number;
+            const author = context.payload.sender.login;
+
+            const body = [
+              `Hi @${author}, thanks for your interest in legalmattic.`,
+              ``,
+              `This repository is the public source of Automattic's legal documents`,
+              `and only accepts changes from Automattic team members. We can't review`,
+              `or merge external contributions here.`,
+              ``,
+              `If you spotted something worth flagging, please reach out via`,
+              `[Automattic support](https://wordpress.com/help/contact).`,
+            ].join('\n');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: number,
+              body,
+            });
+
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: number,
+              state: 'closed',
+              state_reason: 'not_planned',
+            });


### PR DESCRIPTION
## Summary

Restricts new issues and PRs on this repo to Automattic team members. Two workflows, working together:

- **restrict-contributions.yml** — runs on `issues: opened` and `pull_request_target: opened`. If the author's `author_association` isn't `MEMBER`, `OWNER`, or `COLLABORATOR`, it posts a polite "thanks but we only accept changes from Automattic team members" comment and closes the issue/PR. No secrets needed — `author_association` from the event payload is authoritative for org membership (including private members).
- **renew-interaction-limits.yml** — monthly cron that re-sets the repo's `collaborators_only` interaction limit (which maxes out at 6 months per GitHub). Belt-and-suspenders: the interaction limit prevents non-collaborators from opening in the first place; the auto-close workflow catches anything that slips through if this job ever fails or is paused.

## Why

The existing interaction limit expires 2026-11-20. Once it lapses, non-Automattic contributors can again open issues/PRs against the legal documents — which we don't accept anyway. This makes the restriction permanent and self-healing.

## Notes

- Existing closed issues/PRs from external users are untouched.
- The renewal job needs `administration: write` on `GITHUB_TOKEN`. If GitHub rejects that for repo-admin endpoints in some org-policy configuration, the fallback is a fine-grained PAT stored as a repo secret.
- README still invites PRs ("please contribute a pull request"). Worth updating in a follow-up to match the new policy, but kept out of scope here so this PR stays focused on enforcement.

## Test plan

- [ ] Merge to master; confirm both workflows appear under Actions.
- [ ] Manually trigger `renew-interaction-limits` via `workflow_dispatch`; confirm the interaction-limit `expires_at` moves out ~6 months.
- [ ] (Optional) Open a test PR from a non-org account against a fork to confirm `restrict-contributions` closes it. Or trust the next real attempt.

Generated with [Claude Code](https://claude.com/claude-code)
