### PR TITLE
Fix renewal workflow: use PAT for admin-only API

### DIFF
--- a/.github/workflows/renew-interaction-limits.yml
+++ b/.github/workflows/renew-interaction-limits.yml
@@ -2,9 +2,14 @@ name: Renew interaction limit
 
 # Refreshes the repository's "collaborators_only" interaction limit
 # before its 6-month expiry runs out. Paired with restrict-contributions.yml:
-# this prevents non-Automattic-org users from opening issues/PRs at all,
-# while restrict-contributions.yml auto-closes anything that slips through
-# (e.g. if this job is ever paused or fails).
+# the interaction limit prevents non-Automattic-org users from opening
+# issues/PRs in the first place, while restrict-contributions.yml auto-closes
+# anything that slips through.
+#
+# Setup: the interaction-limits API is admin-only and the built-in
+# GITHUB_TOKEN cannot grant repo-admin permissions. This workflow needs
+# a fine-grained PAT with "Administration: read and write" on this
+# repository, stored as a repo secret named INTERACTION_LIMIT_TOKEN.
 
 on:
   schedule:
@@ -13,7 +18,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  administration: write
+  contents: read
 
 jobs:
   renew:
@@ -21,6 +26,7 @@ jobs:
     steps:
       - uses: actions/github-script@v7
         with:
+          github-token: ${{ secrets.INTERACTION_LIMIT_TOKEN }}
           script: |
             await github.request('PUT /repos/{owner}/{repo}/interaction-limits', {
               owner: context.repo.owner,


### PR DESCRIPTION
## Summary

Fixes the renewal workflow that I shipped broken in #124. The `administration: write` permission key doesn't exist in GitHub Actions workflows — `GITHUB_TOKEN` cannot be granted admin-level scopes. Manual `workflow_dispatch` returned HTTP 422 "Unexpected value 'administration'".

## Fix

Switch to a fine-grained PAT stored as a repo secret. Required scope: **Administration: read and write** on this repo only.

## Setup needed before merge (or shortly after)

1. Create a fine-grained PAT at https://github.com/settings/personal-access-tokens/new
   - Resource owner: `Automattic`
   - Repository access: only `legalmattic`
   - Repository permissions: `Administration` → Read and write
   - Expiry: 1 year (the workflow's failure mode if the PAT expires is "interaction limit lapses" — auto-close in `restrict-contributions.yml` still catches everything, so this isn't critical infra)
2. Approve the PAT in the org (Automattic likely requires PAT approval)
3. Add the token as a repo secret named `INTERACTION_LIMIT_TOKEN` at https://github.com/Automattic/legalmattic/settings/secrets/actions
4. After merge, trigger the workflow manually via Actions → Renew interaction limit → Run workflow to confirm it works

## Fallback if PAT setup is impractical

If org policy makes PAT creation/approval a hassle, the load-bearing layer is still `restrict-contributions.yml` (auto-close). Worst case: interaction limit lapses 2026-11-20, drive-by attempts get auto-closed with a polite comment instead of being blocked at the UI level. Re-set manually via Settings → Moderation → Interaction limits every ~5 months.

## Test plan

- [ ] Set up PAT + repo secret as above
- [ ] Manually trigger Renew interaction limit workflow
- [ ] Confirm the run succeeds and `expires_at` moves out ~6 months from now

Generated with [Claude Code](https://claude.com/claude-code)
