### PR TITLE
Fix restrict-contributions workflow: author check was always firing

### DIFF
--- a/.github/workflows/restrict-contributions.yml
+++ b/.github/workflows/restrict-contributions.yml
@@ -13,18 +13,26 @@ permissions:
 jobs:
   close-non-member:
     runs-on: ubuntu-latest
-    if: >-
-      github.event.sender.type != 'Bot' &&
-      !contains(fromJSON('["MEMBER", "OWNER", "COLLABORATOR"]'),
-        github.event.pull_request.author_association || github.event.issue.author_association)
     steps:
       - uses: actions/github-script@v7
         with:
           script: |
             const isPR = !!context.payload.pull_request;
-            const number = isPR
-              ? context.payload.pull_request.number
-              : context.payload.issue.number;
+            const obj = isPR ? context.payload.pull_request : context.payload.issue;
+            const association = obj.author_association;
+            const senderType = context.payload.sender.type;
+
+            const allowed = ['MEMBER', 'OWNER', 'COLLABORATOR'];
+            if (allowed.includes(association)) {
+              core.info(`Skipping: author_association=${association}`);
+              return;
+            }
+            if (senderType === 'Bot') {
+              core.info('Skipping: sender is a bot');
+              return;
+            }
+
+            const number = obj.number;
             const author = context.payload.sender.login;
 
             const body = [


### PR DESCRIPTION
## Summary

Fixes the bug shipped in #124 that caused the restrict-contributions workflow to auto-close every PR — including from Automattic org members. PRs #125 and #126 were both closed by the buggy version.

## The bug

The job-level `if:` used:

```yaml
github.event.pull_request.author_association || github.event.issue.author_association
```

GitHub Actions `||` is **boolean OR with type coercion**, not JavaScript-style nullish coalesce. So `"MEMBER" || null` evaluates to `true`, then `contains(["MEMBER", "OWNER", "COLLABORATOR"], true)` returns `false`, and the close logic fires on every event regardless of author.

## Fix

Drop the `if:` and move the allowlist check inside the `actions/github-script` step where standard JS semantics apply. Early-returns when `author_association` is `MEMBER`, `OWNER`, or `COLLABORATOR`, or when the sender is a `Bot`. Otherwise comment + close.

## Heads up before merging

`pull_request_target` runs the workflow from the **base branch**, so the buggy version on `master` will auto-close this PR too. Just reopen it — same goes for #125 and #126 which were closed by the same bug.

## Test plan

- [ ] Reopen this PR after it auto-closes (sigh)
- [ ] Merge
- [ ] Reopen #125 and #126
- [ ] Open one more test PR from your account — confirm it stays open
- [ ] (Optional) trigger a no-op event from a non-member account to confirm the close logic still fires for them

Generated with [Claude Code](https://claude.com/claude-code)
